### PR TITLE
Adding functionality for thinning chains and using SlicedCore with PT

### DIFF
--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -225,7 +225,7 @@ class Core(object):
             pass
         else:
             self.set_fancy_par_names(fancy_par_names)
-        
+
         if true_vals is not None:
             try:
                 if self.corepath is not None:
@@ -259,7 +259,7 @@ class Core(object):
         """
         return self.get_param(param, to_burn=to_burn)
 
-    def get_param(self, param, to_burn=True, temp=1.0):
+    def get_param(self, param, to_burn=True):
         """
         Returns array of samples for the parameter given.
 
@@ -271,7 +271,32 @@ class Core(object):
             try:
                 idx = self.params.index(param)
             except ValueError:
-                msg = f'\'{param}\' not in list.\nMust use on of:\n{self.params}'
+                msg = f'\'{param}\' not in list.\nMust use one of:\n{self.params}'
+                raise ValueError(msg)
+        try:
+            if to_burn:
+                return self.chain[self.burn:, idx]
+            else:
+                return self.chain[:, idx]
+        except:  # when the chain is 1D:
+            if to_burn:
+                return self.chain[self.burn:]
+            else:
+                return self.chain
+
+    def get_hot_param(self, param, to_burn=True, temp=1.0):
+        """
+        Returns array of samples for the parameter given.
+
+        `param` can either be a single list or list of strings.
+        """
+        if isinstance(param, (list, np.ndarray)):
+            idx = [self.params.index(p) for p in param]
+        else:
+            try:
+                idx = self.params.index(param)
+            except ValueError:
+                msg = f'\'{param}\' not in list.\nMust use one of:\n{self.params}'
                 raise ValueError(msg)
         try:
             if to_burn and temp == 1.0:

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -264,6 +264,10 @@ class Core(object):
         Returns array of samples for the parameter given.
 
         `param` can either be a single list or list of strings.
+
+        `thin_by` will thin the returned array by that integer value.
+
+        `to_burn` will use the Core.burn value to ignore a portion of the chain.
         """
         if isinstance(param, (list, np.ndarray)):
             idx = [self.params.index(p) for p in param]

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -259,7 +259,7 @@ class Core(object):
         """
         return self.get_param(param, to_burn=to_burn)
 
-    def get_param(self, param, to_burn=True):
+    def get_param(self, param, thin_by=1, to_burn=True):
         """
         Returns array of samples for the parameter given.
 
@@ -275,14 +275,14 @@ class Core(object):
                 raise ValueError(msg)
         try:
             if to_burn:
-                return self.chain[self.burn:, idx]
+                return self.chain[self.burn::thin_by, idx]
             else:
-                return self.chain[:, idx]
+                return self.chain[::thin_by, idx]
         except:  # when the chain is 1D:
             if to_burn:
-                return self.chain[self.burn:]
+                return self.chain[self.burn::thin_by]
             else:
-                return self.chain
+                return self.chain[::thin_by]
 
     def get_hot_param(self, param, to_burn=True, temp=1.0):
         """
@@ -300,22 +300,22 @@ class Core(object):
                 raise ValueError(msg)
         try:
             if to_burn and temp == 1.0:
-                return self.chain[self.burn:, idx]
+                return self.chain[self.burn::thin_by, idx]
             elif temp == 1.0 and not to_burn:
-                return self.chain[:, idx]
+                return self.chain[::thin_by, idx]
             elif to_burn and temp != 1.0:
-                return self.hot_chains[temp][self.burn:, idx]
+                return self.hot_chains[temp][self.burn::thin_by, idx]
             else:
-                return self.hot_chains[temp][:, idx]
+                return self.hot_chains[temp][::thin_by, idx]
         except:  # when the chain is 1D:
             if to_burn and temp == 1.0:
-                return self.chain[self.burn:]
+                return self.chain[self.burn::thin_by]
             elif temp == 1.0 and not to_burn:
-                return self.chain
+                return self.chain[::thin_by]
             elif to_burn and temp != 1.0:
-                return self.hot_chains[temp][self.burn:]
+                return self.hot_chains[temp][self.burn::thin_by]
             else:
-                return self.hot_chains[temp]
+                return self.hot_chains[temp][::thin_by]
 
 
     def get_map_param(self, param):

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -284,7 +284,7 @@ class Core(object):
             else:
                 return self.chain[::thin_by]
 
-    def get_hot_param(self, param, to_burn=True, temp=1.0):
+    def get_hot_param(self, param, thin_by=1, to_burn=True, temp=1.0):
         """
         Returns array of samples for the parameter given.
 
@@ -316,7 +316,6 @@ class Core(object):
                 return self.hot_chains[temp][self.burn::thin_by]
             else:
                 return self.hot_chains[temp][::thin_by]
-
 
     def get_map_param(self, param):
         """

--- a/la_forge/slices.py
+++ b/la_forge/slices.py
@@ -55,6 +55,10 @@ class SlicesCore(Core):
         params : list of str
             User defined names of parameters in constructed array.
 
+        pt_chains : bool
+            Whether to load all higher temperature chains from a parallel tempering
+            (PT) analysis. Assumes 1 entry in `slicedirs`.
+
         parfile : str
             Name of parameter list file in the directories that corresponds to
             columns of the chains.

--- a/la_forge/slices.py
+++ b/la_forge/slices.py
@@ -3,6 +3,7 @@
 
 import os.path
 import sys
+import glob
 
 import numpy as np
 
@@ -33,7 +34,7 @@ class SlicesCore(Core):
 
     def __init__(self, label=None, slicedirs=None, pars2pull=None, params=None,
                  corepath=None, fancy_par_names=None, verbose=True,
-                 burn=0.25, parfile='pars.txt'):
+                 burn=0.25, pt_chains=False, parfile='pars.txt'):
         """
         Parameters
         ----------
@@ -76,11 +77,36 @@ class SlicesCore(Core):
         else:
             self.slicedirs = slicedirs
             self.pars2pull = pars2pull
-            # Get indices from par file.
 
+            # Get indices from par file.
             idxs = []
             if isinstance(pars2pull, str):
                 pars2pull = [pars2pull]
+
+            if pt_chains and isinstance(slicedirs, list) and len(slicedirs)>1:
+                raise NotImplementedError('PT Chain SlicedCore only supported for 1 directory.')
+
+            if pt_chains and (any([isinstance(p2p, list) for p2p in pars2pull])
+                              or len(pars2pull)>1):
+                raise NotImplementedError('PT Chain SlicedCore only supported for 1 parameter.')
+
+            if isinstance(slicedirs, str):
+                slicedirs = [slicedirs]
+
+            if pt_chains:
+                self.chainpaths = sorted(glob.glob(slicedirs[0] + '/chain*.txt'))
+                if params is None:
+                    params = [chp.split('/')[-1].split('_')[-1].replace('.txt', '')
+                              for chp in self.chainpaths]
+
+                slicedirs = [slicedirs[0] for ch in self.chainpaths]
+            else:
+                self.chainpaths = []
+                for chaindir in slicedirs:
+                    if os.path.exists(chaindir + '/chain_1.txt'):
+                        self.chainpaths.append(chaindir + '/chain_1.txt')
+                    elif os.path.exists(chaindir + '/chain_1.0.txt'):
+                        self.chainpaths.append(chaindir + '/chain_1.0.txt')
 
             # chain_params = []
             if isinstance(pars2pull[0], list):
@@ -92,7 +118,7 @@ class SlicesCore(Core):
                     file = dir + '/' + parfile
                     idxs.append(get_idx(pars2pull, file))
 
-            chain_list = store_chains(slicedirs, idxs, verbose=verbose)
+            chain_list = store_chains(self.chainpaths, idxs, verbose=verbose)
 
             # Make all chains the same length by truncating to length of shortest.
             chain_lengths = [len(ch) for ch in chain_list]
@@ -108,33 +134,6 @@ class SlicesCore(Core):
             super().__init__(label=label, chain=chain, params=params,
                              burn=burn, fancy_par_names=fancy_par_names,
                              corepath=None)
-
-    # def get_ul_slices_err(self, q=95.0):
-    #     self.ul = np.zeros((len(self.params), 2))
-    #     for ii, yr in enumerate(self.params):
-    #         try:
-    #             if ent_ext_present:
-    #                 self.ul[ii, :] = model_utils.ul(self.chain[self.burn:, ii],
-    #                                                 q=q)
-    #             else:
-    #                 err_msg = 'Must install enterprise_extensions to'
-    #                 err_msg += ' use this functionality.'
-    #                 raise ImportError(err_msg)
-    #         except ZeroDivisionError:
-    #             self.ul[ii, :] = (np.percentile(self.chain[self.burn:, ii], q=q), np.nan)
-    #     return self.ul
-    #
-    # def get_bayes_fac(self, ntol=200, logAmin=-18, logAmax=-12,
-    #                   nsamples=100, smallest_dA=0.01, largest_dA=0.1):
-    #     self.bf = np.zeros((len(self.params), 2))
-    #     for ii, yr in enumerate(self.params):
-    #         self.bf[ii, :] = utils.bayes_fac(self.chain[self.burn:, ii],
-    #                                          ntol=ntol, nsamples=nsamples,
-    #                                          logAmin=logAmin,
-    #                                          logAmax=logAmax,
-    #                                          smallest_dA=smallest_dA,
-    #                                          largest_dA=largest_dA)
-    #     return self.bf
 
 
 def get_idx(par, filename):
@@ -172,21 +171,17 @@ def get_col(col, filename):
 def store_chains(filepaths, idxs, verbose=True):
     chains = []
     for idx, path in zip(idxs, filepaths):
-        if os.path.exists(path + '/chain_1.txt'):
-            ch_path = path + '/chain_1.txt'
-        elif os.path.exists(path + '/chain_1.0.txt'):
-            ch_path = path + '/chain_1.0.txt'
         if isinstance(idx, (list, np.ndarray)):
             for id in idx:
-                chains.append(get_col(id, ch_path))
+                chains.append(get_col(id, path))
         else:
-            chains.append(get_col(idx, ch_path))
+            chains.append(get_col(idx, path))
         if verbose:
             if sys.version_info[0] < 3:
-                print('\r{0} is loaded.'.format(ch_path), end='')
+                print('\r{0} is loaded.'.format(path), end='')
                 sys.stdout.flush()
             else:
-                print('\r{0} is loaded.'.format(ch_path), end='', flush=True)
+                print('\r{0} is loaded.'.format(path), end='', flush=True)
 
     if verbose:
         print('\n')

--- a/tests/test_la_forge.py
+++ b/tests/test_la_forge.py
@@ -74,6 +74,7 @@ def test_core_from_ptmcmc_chains():
     assert hasattr(c0, 'get_param')
     assert hasattr(c0, 'params')
     assert np.array_equal(c0(c0.params[0]), c0.get_param(c0.params[0]))  # Test __call__
+    assert np.array_equal(c0(c0.params[2])[::10], c0.get_param(c0.params[2], thin_by=10))
     assert isinstance(c0.get_map_dict(), dict)
     assert isinstance(c0.credint(c0.params[0], onesided=True, interval=95), float)
     assert isinstance(c0.credint(c0.params[0]), tuple)

--- a/tests/test_slices.py
+++ b/tests/test_slices.py
@@ -30,3 +30,18 @@ def test_slice_core():
     sl.save(corepath)
     sl2 = slices.SlicesCore(corepath=corepath)
     assert isinstance(sl2('J1713+0747_red_noise_gamma'), np.ndarray)
+
+
+def test_slice_core_pt():
+    slicedirs = [chaindir]
+    pars2pull = ['J1713+0747_red_noise_log10_A']
+    sl = slices.SlicesCore(slicedirs=slicedirs,
+                           pars2pull=pars2pull,
+                           params=None,
+                           pt_chains=True)
+    corepath = os.path.join(testdir, 'test_hdf5_pt_slice.core')
+    print(sl.params)
+    print(sl('1.0'))
+    sl.save(corepath)
+    sl2 = slices.SlicesCore(corepath=corepath)
+    assert isinstance(sl2('1.0'), np.ndarray)


### PR DESCRIPTION
This PR adds a flag in `Core.get_param` called `thin_by` which thins the chains by that integer. 

The `SlicesCore` object can now pull the columns from a set of Parallel tempered chains that are in the same directory. This is useful for thermodynamic integration. 