### PR TITLE
[WIP] Don't need to calculate cdf with np.where to plot p-p plot

### DIFF
--- a/la_forge/diagnostics.py
+++ b/la_forge/diagnostics.py
@@ -468,7 +468,8 @@ def pp_plot(corefolder, param, outdir=None):
     sigma = np.sqrt(p * (1 - p) / NUM_REALS)
     plt.figure(figsize=(10, 10))
     plt.title(param)
-    plt.plot(q, cdf, color='blue', alpha=0.3)
+    #plt.plot(q, cdf, color='blue', alpha=0.3)      # Don't need cdf to plot pp
+    plt.plot(np.sort(pvals), q, color='blue', alpha=0.3)
     plt.plot(p, p, color='k')
     plt.plot(p, p + sigma, color='gray')
     plt.plot(p, p + 2 * sigma, color='gray')


### PR DESCRIPTION
Don't merge this yet, I first want to have the discussion.

I've been wondering about the following. When making a p-p plot, la forge and some other packages I've seen calculate the cdf by counting realizations with up to a certain p-value. But the p-value is supposed to be distributed according to Uniform(0, 1). That means you can just straight up plot p-value vs q. Compared to the 'counting' way, this means you have slightly more independent datapoins in the p-p plot.

See what I mean at the code diff below. The difference is very minimal, but it's more elegant.

Is there a reason not to be changing this?