### PR TITLE
Add hypermodel weights to hypermodel cores

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Kristina Islo
 * Aaron Johnson
 * Sarah Vigeland
+* Jeremy Baier

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -727,11 +727,12 @@ class HyperModelCore(Core):
                     self.log_weights = {}
                     for ky, val in param_dict.items():
                         self.log_weights.update({int(ky): val})
-		else:
-		    self.log_weights = log_weights
+                else:
+                    self.log_weights = log_weights
             except:
-		pass
-	
+                pass
+
+
         self.nmodels = len(list(self.param_dict.keys()))
 
     def model_core(self, nmodel):

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -596,7 +596,7 @@ class Core(object):
             files. Each member must be (str of attribute, list to append to).
         """
         self._metadata = ['label', 'burn', 'chaindir', 'chainpath', 'runtime_info']
-        self._savedicts = ['jumps', 'jump_fractions', 'hot_chains', 'truths']
+        self._savedicts = ['jumps', 'jump_fractions', 'hot_chains', 'truths', 'log_weights']
         self._savearrays = ['cov', 'rn_freqs']
         self._savelist_of_str = ['priors', 'fancy_par_names']
         if append is not None:

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -691,7 +691,7 @@ class HyperModelCore(Core):
         """
         # Call to add `param_dict` and `log_weights` to dictionaries for hdf5 to search for.
         self.param_dict = param_dict
-	self.log_weights = log_weights
+        self.log_weights = log_weights
         super()._set_hdf5_lists(append=[('param_dict', '_savedicts')])
         super()._set_hdf5_lists(append=[('log_weights', '_savedicts')])
         super().__init__(chaindir=chaindir, burn=burn,

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -732,7 +732,6 @@ class HyperModelCore(Core):
             except:
                 pass
 
-
         self.nmodels = len(list(self.param_dict.keys()))
 
     def model_core(self, nmodel):

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -692,7 +692,7 @@ class HyperModelCore(Core):
         # Call to add `param_dict` and `log_weights` to dictionaries for hdf5 to search for.
         self.param_dict = param_dict
         self.log_weights = log_weights
-        super()._set_hdf5_lists(append=[('param_dict', '_savedicts')])
+        super()._set_hdf5_lists(append=[('param_dict', '_savedicts'), ('log_weights', '_savedicts')])
         #super()._set_hdf5_lists(append=[('log_weights', '_savedicts')])
         super().__init__(chaindir=chaindir, burn=burn,
                          corepath=corepath,

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -693,7 +693,7 @@ class HyperModelCore(Core):
         self.param_dict = param_dict
         self.log_weights = log_weights
         super()._set_hdf5_lists(append=[('param_dict', '_savedicts')])
-        super()._set_hdf5_lists(append=[('log_weights', '_savedicts')])
+        #super()._set_hdf5_lists(append=[('log_weights', '_savedicts')])
         super().__init__(chaindir=chaindir, burn=burn,
                          corepath=corepath,
                          label=label,

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -596,7 +596,7 @@ class Core(object):
             files. Each member must be (str of attribute, list to append to).
         """
         self._metadata = ['label', 'burn', 'chaindir', 'chainpath', 'runtime_info']
-        self._savedicts = ['jumps', 'jump_fractions', 'hot_chains', 'truths', 'log_weights']
+        self._savedicts = ['jumps', 'jump_fractions', 'hot_chains', 'truths']
         self._savearrays = ['cov', 'rn_freqs']
         self._savelist_of_str = ['priors', 'fancy_par_names']
         if append is not None:
@@ -678,7 +678,7 @@ class HyperModelCore(Core):
     """
 
     def __init__(self, label=None, param_dict=None, log_weights=None,
-		 chaindir=None, burn=0.25, corepath=None,
+		         chaindir=None, burn=0.25, corepath=None,
                  fancy_par_names=None, chain=None, params=None,
                  pt_chains=False, skiprows=0):
         """
@@ -693,7 +693,6 @@ class HyperModelCore(Core):
         self.param_dict = param_dict
         self.log_weights = log_weights
         super()._set_hdf5_lists(append=[('param_dict', '_savedicts'), ('log_weights', '_savedicts')])
-        #super()._set_hdf5_lists(append=[('log_weights', '_savedicts')])
         super().__init__(chaindir=chaindir, burn=burn,
                          corepath=corepath,
                          label=label,

--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -720,12 +720,12 @@ class HyperModelCore(Core):
 	# search for hypermodel weights and add them to core if found
         if self.log_weights is None and corepath is None:
             try:
-                with open(chaindir + '/log_weights.json', 'r') as fin:
+                with open(chaindir + '/model_log_weights.json', 'r') as fin:
                     log_weights = json.load(fin)
 
                 if any([isinstance(ky, str) for ky in log_weights]):
                     self.log_weights = {}
-                    for ky, val in param_dict.items():
+                    for ky, val in log_weights.items():
                         self.log_weights.update({int(ky): val})
                 else:
                     self.log_weights = log_weights


### PR DESCRIPTION
This PR searches a chain directory for a `model_log_weights.json` file when creating a hypermodel core. It stores these weights in the HypermodelCore. 
Additional functionality might include weighted noise flower plots or nmodel histograms.
I am attempting to make a PR in enterprise extensions, which will automatically save hm weights to the chain directory.