### PR TITLE
Update np.loadtxt problem with non-character delimiters

### DIFF
--- a/la_forge/core.py
+++ b/la_forge/core.py
@@ -180,7 +180,7 @@ class Core(object):
 
             try:
                 prior_path = glob.glob(chaindir + '/priors.txt')[0]
-                self.priors = np.loadtxt(prior_path, dtype=str, delimiter='\t')
+                self.priors = np.genfromtxt(prior_path ,dtype=str,delimiter='\n')
             except (FileNotFoundError, IndexError):
                 self.priors = None
 


### PR DESCRIPTION
Found a bug with loading in priors.txt where np.loadtxt() uses the argument delimiter='\t' which is no longer supported by numpy. Updated this to use np.genfromtxt() and use delimiter='\n' instead, as enterprise_extensions's setup_sampler() function outputs each prior on a new line