### PR TITLE
feat(arviz): add arviz import and export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ astropy>=3.0
 corner
 six
 h5py>=3.4.0
+arviz>=0.19.0

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,23 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['numpy>=1.16',
-                'scipy>=1.0.0',
-                'matplotlib>=2.0.0',
-                'corner',
-                'h5py>=3.4.0',
-                'astropy>=3.0',
-                'six',
+requirements = [
+    "numpy>=1.16",
+    "scipy>=1.0.0",
+    "matplotlib>=2.0.0",
+    "corner",
+    "h5py>=3.4.0",
+    "astropy>=3.0",
+    "six",
+    "arviz>=0.19.0",
+    "zarr>=2.5.0,<3",
+    "netcdf4",
+    "xarray-datatree",
+    "dm-tree",
+    "contourpy",
+    "bokeh>=3",
 
-                ]
+]
 
 test_requirements = ['pytest', ]
 


### PR DESCRIPTION
This PR implements a very basic import and export scheme with ArviZ.

### Checks for new file types
If it finds netcdf ".nc" or zarr ".zarr" files, it tries to read them with ArviZ. 
https://github.com/nanograv/la_forge/blob/6d230691559db4afc9ce28d75e23278432980337/la_forge/core.py#L118-L126

### Converts ArviZ data and metadata into a single "chain" for La Forge to consume 
It filters out any parameters that do not correspond to samples in the chain. This means that the number of parameters always equals the number of columns in the chain. It therefore skips the check later on that would add extra PTMCMC parameters, such as `lnpost`.

In this implementation, you need to have already named your variables in the ArviZ `InferenceData` object to their desired final names. I would recommend naming them to their usual PTMCMC values for backwards compatibility.
https://github.com/nanograv/la_forge/blob/6d230691559db4afc9ce28d75e23278432980337/la_forge/core.py#L127-L129

### Adds an `arviz`  `cached_property` to the `Core` class
 Assuming you have a `Core` named `my_core`, calling `my_core.arviz` will return an ArviZ `InferenceData` object populated with the `Core`'s data.
https://github.com/nanograv/la_forge/blob/6d230691559db4afc9ce28d75e23278432980337/la_forge/core.py#L687-L713

# Self contained example
```python
import arviz as az
from la_forge.core import Core
from pathlib import Path

chain_dir = Path("test_chain/")
chain_dir.mkdir(parents=True, exist_ok=True)

inf_data = az.load_arviz_data("regression1d")
inf_data.to_netcdf(chain_dir/"chain.nc")

az_core = Core(chain_dir.as_posix())
```
```python
>>> print(az_core.chain)
[[ 1.5665029  -1.33202579  1.8831507  -1.34775906  1.21947951]
 [ 1.80178445 -1.18480163  1.8831507  -1.34775906  1.10626457]
 [ 1.84332941 -1.22758633  1.8831507  -1.34775906  1.0078494 ]
 ...
 [ 1.68224315 -1.18911818  1.8831507  -1.34775906  0.91507343]
 [ 2.01824417 -1.34356813  1.8831507  -1.34775906  1.14519821]
 [ 1.94768056 -1.37682251  1.8831507  -1.34775906  0.99698405]]

>>> print(az_core.params)
['slope', 'intercept', 'true_slope', 'true_intercept', 'eps']
```

```python
>>> print(az_core.arviz)
Inference data with groups:
	> posterior

>>> print(az_core.arviz.posterior)
<xarray.Dataset> Size: 96kB
Dimensions:         (chain: 1, draw: 2000)
Coordinates:
  * chain           (chain) int64 8B 0
  * draw            (draw) int64 16kB 0 1 2 3 4 5 ... 1995 1996 1997 1998 1999
Data variables:
    slope           (chain, draw) float64 16kB 1.567 1.802 1.843 ... 2.018 1.948
    intercept       (chain, draw) float64 16kB -1.332 -1.185 ... -1.344 -1.377
    true_slope      (chain, draw) float64 16kB 1.883 1.883 1.883 ... 1.883 1.883
    true_intercept  (chain, draw) float64 16kB -1.348 -1.348 ... -1.348 -1.348
    eps             (chain, draw) float64 16kB 1.219 1.106 1.008 ... 1.145 0.997
Attributes:
    source:      la_forge_core
    created_at:  2024-10-04T00:00:57+00:00
```